### PR TITLE
[feat] 카카오 지도 api 연동 및 지도 컴포넌트 추가

### DIFF
--- a/sambakja/index.html
+++ b/sambakja/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -8,6 +8,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <!--카카오맵 API-->
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAOMAP_KEY%&libraries=services,clusterer"
+    ></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/sambakja/package-lock.json
+++ b/sambakja/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^17.2.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-kakao-maps-sdk": "^1.2.0",
         "react-router-dom": "^7.8.0",
         "styled-components": "^6.1.19"
       },
@@ -273,6 +274,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2505,6 +2515,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2826,6 +2842,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.0.tgz",
+      "integrity": "sha512-ptyHhtSbvyza+9IAf6TXjE4ZhwwLbXR6avgNM2ju5xed2+fDwJ+gJDFSqhfsKbvFn9K9+3I+dY3JrqruwsGNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-refresh": {

--- a/sambakja/package.json
+++ b/sambakja/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^17.2.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-kakao-maps-sdk": "^1.2.0",
     "react-router-dom": "^7.8.0",
     "styled-components": "^6.1.19"
   },

--- a/sambakja/src/App.jsx
+++ b/sambakja/src/App.jsx
@@ -6,6 +6,7 @@ import PolicyGuidePage from "./pages/PolicyGuidePage";
 import AboutPage from "./pages/AboutPage";
 import IndustryRecommendationQuestion from "./components/IndustryRecommendationQuestion";
 import IndustryRecommendationReport from "./components/IndustryRecommendationReport";
+import Map from "./components/KakaoMap";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
         <Route path="/ab" element={<AboutPage />} />
         <Route path="/irq" element={<IndustryRecommendationQuestion />} />
         <Route path="/irr" element={<IndustryRecommendationReport />} />
+        <Route path="/map" element={<Map />} />
       </Routes>
     </BrowserRouter>
   );

--- a/sambakja/src/components/KakaoMap.jsx
+++ b/sambakja/src/components/KakaoMap.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Map } from "react-kakao-maps-sdk";
+
+export default function KakaoMap(props) {
+  return (
+    <Map
+      center={{ lat: 33.450701, lng: 126.570667 }}
+      style={{ width: "2000px", height: "900px" }}
+      level={3}
+    />
+  );
+}


### PR DESCRIPTION
## 이슈
#17 

## Description

- 카카오 지도 api 연동
- react-kakao-maps-sdk 설치
- 기본 지도 컴포넌트 추가
- 카카오맵 API 스크립트 로드
